### PR TITLE
Fix gmpl extra args

### DIFF
--- a/gmpl-mode.el
+++ b/gmpl-mode.el
@@ -359,7 +359,7 @@ exact location of `glpsol'.")
                     "--ranges" gmpl--glpsol-ranges-file-name))
         proc)
     (when gmpl-glpsol-extra-args
-      (setq args (cons gmpl-glpsol-extra-args args)))
+      (setq args (append args (split-string gmpl-glpsol-extra-args))))
     (gmpl--glpsol-output-setup)
     (set-process-filter
      (setq proc (apply #'start-process gmpl--glpsol-process-name


### PR DESCRIPTION
Using extra arguments for glpsol seems to not work properly. In `gmpl--send-region-to-glpsol`, the entire extra arguments string `gmpl-glpsol-extra-args` is just attached at the beginning of `args`. This effectively means it's used as the actual command or file to be executed and thus doesn't work. I was able to modify this line to fix the issue (I don't know if it is the best way to fix it; my elisp experience is limited).